### PR TITLE
Adjusted publication-request properties to correctly look at cqframework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
- 
+https://build.fhir.org/ig/cqframework/cms-qmd/branches/main/ 
+
+
 CMS FHIR Quality Measure Development IG
 This IG is intended to provide guidance and conformances used in the development of CMS FHIR measures. 
 CI Build for master branch:  

--- a/publication-request.json
+++ b/publication-request.json
@@ -6,10 +6,10 @@
     "status": "draft",
     "sequence": "Releases",
     "desc": "Initial development draft",
-    "descmd": "Initial **draft** release of CMS QMD IG",
+    "descmd": "Initial draft release of CMS QMD IG",
     "first": true,
     "title": "CMS FHIR Quality Measure Development IG",
-    "ci-build": "http://build.fhir.org/ig/cqframework/qmd",
+    "ci-build": "http://build.fhir.org/ig/cqframework/cms-qmd",
     "category": "Clinical",
     "introduction": "An Implementation Guide for CMS Quality Measure Development using FHIR."
 }


### PR DESCRIPTION
This merge is meant to trigger a build and provide a url such as  https://build.fhir.org/ig/cqframework/cms-qmd/branches/main/